### PR TITLE
feat: redesign UI and harden discovery flow

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,2 +1,3 @@
 OMDB_API_KEY='your_omdb_api_key'
 TMDB_API_KEY="your_tmdb_api_key"
+FLASK_DEBUG=1               # 1 = Debug On, 0 = Debug Off

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/myenv
+**/.venv
 **/__pycache__
 
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.13
+FROM python:3.11.13-slim
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ Before you get started, ensure you have the following:
 ### ⚙️ **Setup**
 
 1. **Clone the repository**:
-
-   ```bash
-   git clone https://github.com/soulaymanebe/movies-app
-   cd movies-app
-    ```
-
-2. **Install dependencies**:
-
-    ```bash
-    pip install -r requirements.txt
-    ```
-
-3. **Prepare the `.env` file**:
+2. **Create a virtual env**:
+3. **Install dependencies**:
+4. **Prepare the `.env` file**:
     Create a .env file in the root directory and add your OMDB API key, check `.env-example` file for instructions
+5. **Export .env vars**
+
+```
+git clone https://github.com/soulaymanebe/movies-app
+cd movies-app
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+export $(grep -v '^#' .env | xargs)
+```
 
 ---
 
@@ -41,6 +41,7 @@ Before you get started, ensure you have the following:
 ### On Linux
 
 ```bash
+flask --app source.app run --debug # Debug mode
 gunicorn source.app:app --bind 0.0.0.0:5000
 ```
 

--- a/source/app.py
+++ b/source/app.py
@@ -1,96 +1,182 @@
-from flask import Flask, render_template, request
-from flask_caching import Cache
-import unicodedata
+import logging
+import os
 import re
+import unicodedata
+
+from flask import Flask, render_template, request, abort
+from flask_caching import Cache
+
 from source.config import Config
 from source.helper import Helper
 
-# Prepare env
-app = Flask(__name__)
-cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
-# Clean special characters
-@app.template_filter('slugify')
-def slugify(value):
-    value = unicodedata.normalize('NFD', value)
-    value = value.encode('ascii', 'ignore').decode('utf-8')
-    value = re.sub(r'[^a-zA-Z0-9]+', '-', value)
-    return value.strip('-')
+def create_app():
+    app = Flask(__name__)
 
-# Main endpoint
-@app.route('/', methods=['GET'])
-def index():
-    return render_template('index.html')
+    app.config.update(
+        CACHE_TYPE=os.getenv("CACHE_TYPE", "SimpleCache"),
+        CACHE_DEFAULT_TIMEOUT=int(os.getenv("CACHE_TIMEOUT", "300")),
+    )
+    cache = Cache(app)
 
-# Results endpoint
-@cache.cached(timeout=300, query_string=True)
-@app.route('/results/<search_request>')
-def results(search_request):
-    # Try OMDB search
-    search_data = Helper.search_omdb(search_request)
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    logger = logging.getLogger("tmenyik")
 
-    # Fallback to TMDB suggestions
-    if not search_data:
-        tmdb_suggestions = Helper.search_tmdb(search_request)
-        if tmdb_suggestions:
-            search_data = Helper.search_omdb(tmdb_suggestions[0])
+    # --- Jinja filter ---
+    @app.template_filter("slugify")
+    def slugify(value):
+        value = unicodedata.normalize("NFD", value or "")
+        value = value.encode("ascii", "ignore").decode("utf-8")
+        value = re.sub(r"[^a-zA-Z0-9]+", "-", value)
+        return value.strip("-")
 
-    if not search_data:
-        return render_template('index.html', error="No results found. Try different keywords.")
+    def safe_int(raw, default=1, minimum=1):
+        try:
+            return max(minimum, int(raw))
+        except (TypeError, ValueError):
+            return default
 
-    # Fetch detailed info
-    results = search_data.get('Search', [])
-    detailed_results = Helper.omdb_details(results)
+    # --- Routes ---
+    @app.route("/", methods=["GET"])
+    def index():
+        return render_template("index.html")
 
-    return render_template('select.html', results=detailed_results, search_request=search_request)
+    @app.route("/results/<search_request>")
+    def results(search_request):
+        cache_key = f"results:{search_request}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
 
-# Watch endpoint
-@cache.cached(timeout=300, query_string=True)
-@app.route('/watch/<title>')
-def watch(title):
-    imdb_id = request.args.get('id')
-    season = int(request.args.get('season', 1))
-    episode = int(request.args.get('episode', 1))
-    title = title.replace('-', ' ')
+        try:
+            search_data = Helper.search_omdb(search_request)
 
-    # Fetch all informations
-    infos = Helper.omdb_details([{"imdbID": imdb_id}])[0]
-    if not infos:
-        return render_template('watch.html', error_message="Failed to load movie details")
-    
-    content_type = infos.get('Type', "N/A")
-    title = infos.get('Title', "N/A")
-    plot = infos.get('Plot', "N/A")
+            # Fallback: let TMDB correct the spelling, then re-query OMDB
+            if not search_data:
+                suggestions = Helper.search_tmdb(search_request)
+                if suggestions:
+                    search_data = Helper.search_omdb(suggestions[0])
 
-    # Build embed URL + seasons if series
-    if content_type == 'series':
-        embed_url = Config.working_vidsrc_url('series', imdb_id, season, episode)
-        total_seasons = int(infos.get('totalSeasons', 0))
-        seasons_object = Helper.seasons_and_episodes(imdb_id, total_seasons)
-    else:
-        embed_url = Config.working_vidsrc_url('movie', imdb_id)
-        total_seasons = None
-        seasons_object = None
+            if not search_data:
+                return render_template(
+                    "index.html",
+                    error="No results found. Try different keywords.",
+                )
 
-    # watch.html details
-    details = {
-        "embed_url": embed_url,
-        "title": title,
-        "plot": plot,
-        "type": content_type,
-        "seasons_object": seasons_object,
-        "current_episode": episode,
-        "current_season": season,
-        "total_seasons": total_seasons,
-        "imdb_id": imdb_id,
-    }
+            # Keep only movies and series — OMDB also returns games and episodes.
+            items = [
+                i for i in search_data.get("Search", [])
+                if i.get("Type") in ("movie", "series")
+            ]
+            if not items:
+                return render_template(
+                    "index.html",
+                    error="No movies or series found. Try different keywords.",
+                )
 
-    return render_template('watch.html', **details)
+            detailed = Helper.omdb_details(items)
+            detailed = [d for d in detailed if d.get("Type") in ("movie", "series")]
+            if not detailed:
+                # Details all failed (likely network) — don't cache an empty page.
+                return render_template(
+                    "index.html",
+                    error="Couldn't load details right now. Please try again.",
+                )
 
-# 404 error handler
-@app.errorhandler(404)
-def page_not_found(error):
-    return render_template('404.html'), 404
+            html = render_template(
+                "select.html",
+                results=detailed,
+                search_request=search_request,
+            )
+            cache.set(cache_key, html, timeout=300)  # cache the good result only
+            return html
+        except Exception:
+            logger.exception("results() failed for %r", search_request)
+            return render_template(
+                "index.html",
+                error="Something went wrong while searching. Please try again.",
+            )
 
-if __name__ == '__main__':
-    app.run(debug=True)
+    @app.route("/watch/<title>")
+    def watch(title):
+        imdb_id = request.args.get("id")
+        if not imdb_id:
+            abort(404)
+
+        season = safe_int(request.args.get("season"), default=1)
+        episode = safe_int(request.args.get("episode"), default=1)
+
+        # Only successful renders are cached (keyed on id/season/episode), so a
+        # failed metadata load is never stored and won't stick after reconnect.
+        cache_key = f"watch:{imdb_id}:{season}:{episode}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        try:
+            details_list = Helper.omdb_details([{"imdbID": imdb_id}])
+            infos = details_list[0] if details_list else None
+        except Exception:
+            logger.exception("omdb_details() failed for %s", imdb_id)
+            infos = None
+
+        if not infos:
+            return render_template(
+                "watch.html",
+                error_message="Failed to load movie details.",
+            )
+
+        content_type = infos.get("Type", "N/A")
+        title = infos.get("Title", "N/A")
+        plot = infos.get("Plot", "N/A")
+
+        if content_type == "series":
+            embed_url = Config.working_vidsrc_url("series", imdb_id, season, episode)
+            total_seasons = safe_int(infos.get("totalSeasons"), default=0, minimum=0)
+            seasons_object = Helper.seasons_and_episodes(imdb_id, total_seasons)
+        else:
+            embed_url = Config.working_vidsrc_url("movie", imdb_id)
+            total_seasons = None
+            seasons_object = None
+
+        html = render_template(
+            "watch.html",
+            embed_url=embed_url,
+            title=title,
+            plot=plot,
+            type=content_type,
+            seasons_object=seasons_object,
+            current_episode=episode,
+            current_season=season,
+            total_seasons=total_seasons,
+            imdb_id=imdb_id,
+        )
+        cache.set(cache_key, html, timeout=300)
+        return html
+
+    # Lightweight health check
+    @app.route("/healthz")
+    def healthz():
+        return {"status": "ok"}, 200
+
+    # --- Error handlers ---
+    @app.errorhandler(404)
+    def page_not_found(error):
+        return render_template("404.html"), 404
+
+    @app.errorhandler(500)
+    def server_error(error):
+        logger.exception("Unhandled server error")
+        return render_template("500.html"), 500
+
+    return app
+
+
+app = create_app()
+
+if __name__ == "__main__":
+    # debug is OFF unless explicitly enabled
+    app.run(debug=os.getenv("FLASK_DEBUG", "0") == "1")

--- a/source/config.py
+++ b/source/config.py
@@ -1,8 +1,12 @@
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+
 import requests
 
-# Other domains
-VIDSRC_DOMAINS = [
+logger = logging.getLogger("tmenyik.config")
+
+_DEFAULT_DOMAINS = [
     "vidsrcme.ru",
     "vidsrcme.su",
     "vidsrc-me.ru",
@@ -12,29 +16,41 @@ VIDSRC_DOMAINS = [
     "vsrc.su"
 ]
 
+VIDSRC_DOMAINS = [
+    d.strip()
+    for d in os.getenv("VIDSRC_DOMAINS", ",".join(_DEFAULT_DOMAINS)).split(",")
+    if d.strip()
+]
+
+_session = requests.Session()
+
 class Config:
     @staticmethod
     def working_vidsrc_url(content_type, imdb_id, season=None, episode=None):
         def build_url(domain):
-            if content_type == 'series':
+            if content_type == "series":
                 return f"https://{domain}/embed/tv/{imdb_id}/{season}-{episode}?ads=false"
-            else:
-                return f"https://{domain}/embed/movie/{imdb_id}?ads=false"
+            return f"https://{domain}/embed/movie/{imdb_id}?ads=false"
 
-        def check_domain(domain):
+        def is_reachable(domain):
             url = build_url(domain)
             try:
-                resp = requests.get(url, timeout=3)
-                if resp.status_code == 200:
-                    return url
+                resp = _session.get(url, timeout=3, stream=True)
+                resp.close()
+                return url if resp.status_code == 200 else None
             except requests.exceptions.RequestException:
                 return None
+
+        if not VIDSRC_DOMAINS:
+            logger.warning("No embed domains configured (set VIDSRC_DOMAINS).")
             return None
 
         with ThreadPoolExecutor(max_workers=len(VIDSRC_DOMAINS)) as executor:
-            futures = {executor.submit(check_domain, domain): domain for domain in VIDSRC_DOMAINS}
-            for future in as_completed(futures):
-                result = future.result()
-                if result:
-                    return result
+            results = dict(zip(VIDSRC_DOMAINS, executor.map(is_reachable, VIDSRC_DOMAINS)))
+
+        for domain in VIDSRC_DOMAINS:
+            if results.get(domain):
+                return results[domain]
+
+        logger.info("No reachable embed domain for %s.", imdb_id)
         return None

--- a/source/helper.py
+++ b/source/helper.py
@@ -1,75 +1,148 @@
+import logging
 import os
-import requests
-from dotenv import load_dotenv
 from concurrent.futures import ThreadPoolExecutor
 
+import requests
+from dotenv import load_dotenv
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
 load_dotenv()
+
+logger = logging.getLogger("tmenyik.helper")
+
 OMDB_API_KEY = os.getenv("OMDB_API_KEY")
 TMDB_API_KEY = os.getenv("TMDB_API_KEY")
+
+OMDB_URL = "https://www.omdbapi.com/"
+TMDB_SEARCH_URL = "https://api.themoviedb.org/3/search/multi"
+
+if not OMDB_API_KEY:
+    logger.warning("OMDB_API_KEY is not set — OMDB requests will fail.")
+if not TMDB_API_KEY:
+    logger.warning("TMDB_API_KEY is not set — TMDB fallback is disabled.")
+
+
+def _build_session(pool_size=10):
+    session = requests.Session()
+    retry = Retry(
+        total=2,
+        backoff_factor=0.3,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=("GET", "HEAD"),
+    )
+    adapter = HTTPAdapter(
+        max_retries=retry,
+        pool_connections=pool_size,
+        pool_maxsize=pool_size,
+    )
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+SESSION = _build_session()
 
 class Helper:
     @staticmethod
     def search_tmdb(search_request):
-        tmdb_url = f'https://api.themoviedb.org/3/search/movie?api_key={TMDB_API_KEY}&query={search_request}'
-        try:
-            response = requests.get(tmdb_url)
-            response.raise_for_status()
-            tmdb_data = response.json()
-
-            if tmdb_data.get('results'):
-                return [movie['title'] for movie in tmdb_data['results']]
-            else:
-                return []
-        except requests.exceptions.RequestException as e:
-            print(f"Error querying TMDB: {e}")
+        if not TMDB_API_KEY:
             return []
+        try:
+            resp = SESSION.get(
+                TMDB_SEARCH_URL,
+                params={"api_key": TMDB_API_KEY, "query": search_request},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.exceptions.RequestException as e:
+            logger.warning("TMDB query failed for %r: %s", search_request, e)
+            return []
+
+        titles = []
+        for item in data.get("results", []):
+            if item.get("media_type") in ("movie", "tv"):
+                name = item.get("title") or item.get("name")
+                if name:
+                    titles.append(name)
+        return titles
 
     @staticmethod
     def search_omdb(search_term):
-        search_url = f'http://www.omdbapi.com/?apikey={OMDB_API_KEY}&s={search_term}'
-        try:
-            response = requests.get(search_url, timeout=10)
-            response.raise_for_status()
-            data = response.json()
-            return data if data.get('Response') == 'True' else None
-        except requests.exceptions.RequestException as e:
-            print(f"OMDB search failed: {e}")
+        if not OMDB_API_KEY:
             return None
+        try:
+            resp = SESSION.get(
+                OMDB_URL,
+                params={"apikey": OMDB_API_KEY, "s": search_term},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.exceptions.RequestException as e:
+            logger.warning("OMDB search failed for %r: %s", search_term, e)
+            return None
+        return data if data.get("Response") == "True" else None
 
     @staticmethod
     def omdb_details(imdb_data):
-        imdb_ids = [item["imdbID"] for item in imdb_data if "imdbID" in item]
+        imdb_ids = [item["imdbID"] for item in imdb_data if item.get("imdbID")]
+        if not imdb_ids:
+            return []
 
         def fetch_details(imdb_id):
-            url = f'http://www.omdbapi.com/?apikey={OMDB_API_KEY}&i={imdb_id}'
             try:
-                resp = requests.get(url, timeout=5)
+                resp = SESSION.get(
+                    OMDB_URL,
+                    params={"apikey": OMDB_API_KEY, "i": imdb_id},
+                    timeout=5,
+                )
                 resp.raise_for_status()
                 return resp.json()
-            except requests.exceptions.RequestException:
+            except requests.exceptions.RequestException as e:
+                logger.warning("OMDB details failed for %s: %s", imdb_id, e)
                 return None
 
         results = []
-        with ThreadPoolExecutor(max_workers=10) as executor:  # 10 parallel requests
+        with ThreadPoolExecutor(max_workers=10) as executor:
             for result in executor.map(fetch_details, imdb_ids):
-                if result:
+                if result and result.get("Response") == "True":
                     results.append(result)
         return results
 
     @staticmethod
     def seasons_and_episodes(imdb_id, total_seasons):
-        def fetch_season(s):
-            url = f'http://www.omdbapi.com/?apikey={OMDB_API_KEY}&i={imdb_id}&Season={s}'
+        if total_seasons <= 0:
+            return {}
+
+        def fetch_season(season_num):
             try:
-                resp = requests.get(url, timeout=5)
+                resp = SESSION.get(
+                    OMDB_URL,
+                    params={"apikey": OMDB_API_KEY, "i": imdb_id, "Season": season_num},
+                    timeout=5,
+                )
                 resp.raise_for_status()
-                episodes = resp.json().get('Episodes', [])
-                return (f'Season {s}', [{"title": ep["Title"], "episode": ep["Episode"]} for ep in episodes])
-            except requests.exceptions.RequestException:
-                return (f'Season {s}', [])
-        
+                episodes = resp.json().get("Episodes", []) or []
+            except requests.exceptions.RequestException as e:
+                logger.warning("OMDB season %s failed for %s: %s", season_num, imdb_id, e)
+                return (season_num, [])
+
+            parsed = [
+                {"title": ep.get("Title", "N/A"), "episode": ep.get("Episode", "")}
+                for ep in episodes
+            ]
+
+            parsed.sort(
+                key=lambda ep: int(ep["episode"]) if str(ep["episode"]).isdigit() else 0
+            )
+            return (season_num, parsed)
+
         seasons_object = {}
         with ThreadPoolExecutor(max_workers=10) as executor:
-            for season, episodes in executor.map(fetch_season, range(1, total_seasons + 1)):
-                seasons_object[season] = episodes
+            for season_num, episodes in executor.map(
+                fetch_season, range(1, total_seasons + 1)
+            ):
+                seasons_object[f"Season {season_num}"] = episodes
         return seasons_object

--- a/source/static/styles.css
+++ b/source/static/styles.css
@@ -1,485 +1,871 @@
-body {
-    font-family: Arial, sans-serif;
-    background-color: #1c1c1c;
-    color: #ffffff;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 100vh;
-    text-align: center;
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@500;600;700&family=Inter:wght@400;500;600&family=Space+Mono:wght@400;700&display=swap');
+
+:root {
+    --ink: #0e0d14;
+    --ink-2: #15131d;
+    --surface: #1b1925;
+    --surface-2: #221f2e;
+    --coral: #ff6347;
+    --coral-soft: #ff8a6b;
+    --amber: #ffc27a;
+    --paper: #f4eef0;
+    --muted: #9a93a6;
+    --line: rgba(244, 238, 240, 0.09);
+    --line-strong: rgba(244, 238, 240, 0.16);
+    --glow: rgba(255, 99, 71, 0.30);
+
+    --font-display: 'Bricolage Grotesque', system-ui, sans-serif;
+    --font-body: 'Inter', system-ui, sans-serif;
+    --font-mono: 'Space Mono', ui-monospace, monospace;
+
+    --radius: 16px;
+    --radius-sm: 10px;
+    --shadow: 0 24px 60px -24px rgba(0, 0, 0, 0.7);
 }
 
-.container {
-    width: 60%;
-    max-width: 100%;
-    padding: 20px;
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: var(--font-body);
+    color: var(--paper);
+    background: var(--ink);
+    background-image:
+        radial-gradient(120% 60% at 50% -10%, rgba(255, 99, 71, 0.16) 0%, rgba(255, 99, 71, 0) 55%),
+        radial-gradient(80% 50% at 85% 110%, rgba(127, 90, 240, 0.10) 0%, rgba(127, 90, 240, 0) 60%);
+    background-attachment: fixed;
+    -webkit-font-smoothing: antialiased;
+    line-height: 1.6;
+}
+
+/* Faint vignette + film-grain feel */
+body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    background:
+        radial-gradient(140% 120% at 50% 0%, transparent 60%, rgba(0, 0, 0, 0.5) 100%);
+    mix-blend-mode: multiply;
+}
+
+/* The projector beam */
+.beam {
+    position: fixed;
+    top: -28vh;
+    left: 50%;
+    width: 90vw;
+    max-width: 1100px;
+    height: 70vh;
+    transform: translateX(-50%);
+    background: radial-gradient(50% 60% at 50% 0%, var(--glow) 0%, rgba(255, 99, 71, 0) 70%);
+    filter: blur(6px);
+    pointer-events: none;
+    z-index: 0;
+}
+.beam-soft { opacity: 0.6; }
+
+main, header, .parent-container, .error-container { position: relative; z-index: 1; }
+
+a { color: inherit; }
+
+::selection { background: var(--coral); color: var(--ink); }
+
+/* ---------- Brand + top bar ---------- */
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    text-decoration: none;
+}
+.brand-mark {
+    width: 38px;
+    height: 38px;
+    border-radius: 11px;
+    object-fit: cover;
+    box-shadow: 0 0 0 1px var(--line-strong), 0 8px 20px -8px var(--glow);
+}
+.brand-name {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 24px;
+    letter-spacing: -0.02em;
+    color: var(--paper);
+}
+.brand-sm .brand-mark { width: 30px; height: 30px; border-radius: 9px; }
+.brand-sm .brand-name { font-size: 19px; }
+
+.topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px clamp(16px, 4vw, 40px);
+    max-width: 1240px;
     margin: 0 auto;
 }
 
-.title h1 {
-    font-size: 30px;
-    color: #ff6347;
-}
-
-.title h2 {
-    position: absolute;
-    top: 22px;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 20px;
-    color: #ff6347;
-}
-
-/* Error */
-.error {
-    color: #ff6347;
-}
-
-/* Home button */
 .home-button {
-    display: inline-block;
-    margin: 10px 0;
-    color: #ff6347;
-    font-size: 24px;
-    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 999px;
+    background: rgba(244, 238, 240, 0.05);
+    border: 1px solid var(--line);
+    backdrop-filter: blur(8px);
+    transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+.home-button:hover { background: rgba(255, 99, 71, 0.14); border-color: var(--coral); transform: translateY(-1px); }
+.home-button img { width: 20px; height: 20px; }
+
+/* ---------- Landing / hero ---------- */
+.page-landing { display: grid; place-items: center; }
+
+.landing {
+    width: 100%;
+    max-width: 720px;
+    padding: 8vh clamp(20px, 6vw, 40px) 12vh;
+    text-align: center;
+    animation: rise 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) both;
 }
 
-.home-button i {
-    vertical-align: middle;
+.landing .brand { margin-bottom: 40px; }
+
+.hero-title {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: clamp(36px, 7vw, 64px);
+    line-height: 1.02;
+    letter-spacing: -0.03em;
+    margin: 0 0 18px;
+    background: linear-gradient(180deg, var(--paper) 0%, #d7cdd2 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+}
+.hero-sub {
+    font-size: clamp(15px, 2.4vw, 18px);
+    color: var(--muted);
+    margin: 0 0 36px;
 }
 
-.home-button {
-    display: inline-block;
-    margin: 10px;
-    position: absolute;
-    top: 20px;
-    right: 20px;
+.search-form { width: 100%; }
+.search-field {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 8px 8px 18px;
+    background: rgba(27, 25, 37, 0.7);
+    border: 1px solid var(--line-strong);
+    border-radius: 999px;
+    backdrop-filter: blur(14px);
+    box-shadow: var(--shadow);
+    transition: border-color 0.25s ease, box-shadow 0.25s ease;
 }
-
-.home-button img {
-    width: 30px;
-    height: auto;
+.search-field:focus-within {
+    border-color: var(--coral);
+    box-shadow: var(--shadow), 0 0 0 4px var(--glow);
 }
-
-/* Search */
-.search-form input[type="text"],
-.search-form button {
-    border-radius: 5px;
-    color: #444;
-    padding: 10px;
-    font-size: 16px;
+.search-icon {
+    width: 20px;
+    height: 20px;
+    flex: none;
+    fill: none;
+    stroke: var(--muted);
+    stroke-width: 2;
+    stroke-linecap: round;
+}
+.search-field input {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
     border: none;
-    margin: 10px;
-}
-
-.search-form input[type="text"] {
-    background-color: #444;
-    color: #fff;
-    border: none;
-    width: 50%;
-}
-
-.search-form button {
-    border-radius: 5px;
-    padding: 10px;
+    outline: none;
+    color: var(--paper);
+    font-family: var(--font-body);
     font-size: 16px;
-    background-color: #ff6347;
-    color: #fff;
+    padding: 12px 6px;
+}
+.search-field input::placeholder { color: var(--muted); }
+.search-field button {
+    flex: none;
     border: none;
     cursor: pointer;
-    margin: 10px;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--ink);
+    background: var(--coral);
+    padding: 13px 26px;
+    border-radius: 999px;
+    transition: background 0.2s ease, transform 0.1s ease;
+}
+.search-field button:hover { background: var(--coral-soft); }
+.search-field button:active { transform: scale(0.97); }
+
+/* ---------- Inline error ---------- */
+.error {
+    color: var(--coral-soft);
+    font-size: 14px;
+    margin: 0 0 20px;
+    font-weight: 500;
 }
 
-/* Results */
+/* ---------- Results page ---------- */
+.results-page { max-width: 1240px; margin: 0 auto; padding: 8px clamp(16px, 4vw, 40px) 80px; }
+
+.results-head { margin: 12px 0 28px; }
+.eyebrow {
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 12px;
+    color: var(--coral);
+    margin: 0 0 6px;
+}
+.results-title {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: clamp(26px, 4.5vw, 40px);
+    letter-spacing: -0.02em;
+    margin: 0;
+}
+
 .results-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 15px;
-    justify-content: center;
-    margin-top: 40px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+    gap: clamp(14px, 2vw, 24px);
 }
 
 .result-card {
-    background-color: #2d2d2d;
-    padding: 10px;
-    border-radius: 8px;
-    width: 200px;
-    text-align: center;
-    color: #fff;
-    margin-top: 40px;
     text-decoration: none;
-    transition: transform 0.2s ease;
-    display: block;
-}
-
-.result-card img {
-    width: 100%;
-    height: 300px;
-    border-radius: 5px;
-}
-
-.result-card h2 {
-    font-size: 20px;
-    color: #ff6347;
-    margin-top: 10px;
-}
-
-.result-card:hover {
-    transform: scale(1.05);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-}
-
-.result-info p {
-    font-size: 14px;
-    color: #bbb;
-}
-
-.result-info p {
-    font-size: 14px;
-    color: #bbb;
-}
-
-/* Movie/Serie video player container */
-.video-container {
-    position: relative;
-    /* width: 1024px; */
-    width: 100%;
-    max-width: 1024px;
-    /* height: 600px; */
-    height: auto;
-    /* margin: 0 auto; */
-    margin: 20px auto;
-    aspect-ratio: 16 / 9;
-    background-color: #000;
-    margin-top: 50px;
-    border-radius: 8px;
-    overflow: hidden;
-}
-
-.video-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    border: none;
-    border-radius: 8px;
-}
-
-/* Story Line */
-.plot-container {
-    background-color: #2d2d2d;
-    border-radius: 8px;
-    padding: 10px;
-    margin-top: 15px;
-    color: #fff;
-    text-align: left;
-    margin-top: 20px;
-    max-width: 1024px;
-    width: 100%;
-    box-sizing: border-box;
-    overflow-wrap: break-word;
-}
-
-.plot-container h2 {
-    font-size: 20px;
-    margin-bottom: 10px;
-    color: #ff6347;
-    margin-top: 20px;
-}
-
-.plot-container p {
-    white-space: pre-wrap;
-    word-break: keep-all;
-    overflow-wrap: anywhere;
-    line-height: 1.3;
-    margin-bottom: 1em;
-}
-
-/* Watching page */
-.parent-container {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    padding: 20px;
-}
-@media (max-width: 768px) {
-    .parent-container {
-        flex-direction: column;
-    }
-}
-
-.left-container {
+    color: inherit;
     display: flex;
     flex-direction: column;
-    gap: 20px;
-    height: calc(100vh - 100px);
-    overflow-y: auto;
-    flex-shrink: 0;
+    animation: rise 0.5s cubic-bezier(0.2, 0.7, 0.2, 1) both;
 }
+.result-card:nth-child(1) { animation-delay: 0.02s; }
+.result-card:nth-child(2) { animation-delay: 0.06s; }
+.result-card:nth-child(3) { animation-delay: 0.10s; }
+.result-card:nth-child(4) { animation-delay: 0.14s; }
+.result-card:nth-child(5) { animation-delay: 0.18s; }
+.result-card:nth-child(6) { animation-delay: 0.22s; }
+.result-card:nth-child(n+7) { animation-delay: 0.26s; }
 
-/* All episodes & seasons */
-.seasons-container {
-    background-color: #2d2d2d;
-    border-radius: 8px;
-    padding: 20px;
-    color: #fff;
-    text-align: left;
-    width: 200px;
-    margin-top: 20px;
-    box-sizing: border-box;
-    max-height: 100%;
-    overflow-y: auto;
+.poster-wrap {
+    position: relative;
+    aspect-ratio: 2 / 3;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    transition: transform 0.28s cubic-bezier(0.2, 0.7, 0.2, 1), box-shadow 0.28s ease, border-color 0.28s ease;
 }
-
-.seasons-container h2 {
-    text-align: center;
-    font-size: 20px;
-    color: #ff6347;
-}
-
-/* Season button styling */
-.season-button {
+.poster-wrap img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
     display: block;
-    padding: 8px;
-    background-color: #ff6347;
-    /* color: #ff6347; */
-    border-radius: 5px;
-    text-align: left;
-    font-weight: bold;
-    margin: 5px 0;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
+    transition: transform 0.5s cubic-bezier(0.2, 0.7, 0.2, 1);
 }
-
-.season-button:hover {
-    background-color: #3a3a3a;
+.poster-scrim {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(14, 13, 20, 0) 55%, rgba(14, 13, 20, 0.55) 100%);
 }
-
-/* Episode list styling */
-.episode-list {
-    display: none;
-    background-color: #2d2d2d;
-    border-radius: 5px;
-    padding: 8px;
-    margin-top: 10px;
-    font-size: 14px;
-    transition: all 0.3s ease;
-}
-
-.episode-list.active {
-    display: block;
-}
-
-.episode-list ul {
-    list-style-type: none;
-    padding: 0;
-    margin: 0;
-}
-
-.episode-list li {
-    padding: 8px;
-    border-bottom: 1px solid #444;
-    border-radius: 5px;
-    font-size: 14px;
-    cursor: pointer;
-    transition: color 0.2s ease, background-color 0.2s ease;
-}
-
-.episode-list li a {
-    color: #fff;
-    text-decoration: none;
-    display: block;
-    transition: color 0.2s ease, background-color 0.2s ease;
-}
-
-.episode-list li:last-child {
-    border-bottom: none;
-}
-
-.episode-list li:hover {
-    color: #ff6347;
-    background-color: #3a3a3a;
-}
-
-.episode-list li.selected {
-    background-color: #444;
-    font-weight: bold;
-}
-
-/* Error container */
-.error-container {
+.play-hint {
     position: absolute;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -50%);
-    padding: 40px;
-    text-align: center;
-    max-width: 600px;
-    width: 100%;
-    margin: 0 auto;
+    width: 56px;
+    height: 56px;
+    transform: translate(-50%, -50%) scale(0.7);
+    display: grid;
+    place-items: center;
+    border-radius: 999px;
+    background: rgba(255, 99, 71, 0.92);
+    color: var(--ink);
+    font-size: 20px;
+    padding-left: 3px;
+    opacity: 0;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+}
+.result-card:hover .poster-wrap {
+    transform: translateY(-6px);
+    border-color: rgba(255, 99, 71, 0.5);
+    box-shadow: 0 22px 44px -22px var(--glow), 0 0 0 1px rgba(255, 99, 71, 0.3);
+}
+.result-card:hover .poster-wrap img { transform: scale(1.07); }
+.result-card:hover .play-hint { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+.result-card:focus-visible .poster-wrap {
+    outline: none;
+    border-color: var(--coral);
+    box-shadow: 0 0 0 3px var(--glow);
 }
 
-/* Title styling */
-.error-title {
-    font-size: 160px;
-    color: #ff6347;
-    font-weight: bold;
+.badge {
+    position: absolute;
+    top: 10px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    padding: 5px 9px;
+    border-radius: 8px;
+    backdrop-filter: blur(8px);
+}
+.badge-type {
+    left: 10px;
+    background: rgba(14, 13, 20, 0.66);
+    color: var(--paper);
     text-transform: uppercase;
-    margin-bottom: 5px;
+    border: 1px solid var(--line);
+}
+.badge-rating {
+    right: 10px;
+    background: rgba(255, 194, 122, 0.92);
+    color: #4a2c08;
 }
 
-/* Message styling */
-.error-message {
-    font-size: 18px;
-    color: #bbb;
-    margin-bottom: 35px;
+.result-info { padding: 12px 2px 4px; }
+.result-info h2 {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 1.3;
+    margin: 0 0 5px;
+    color: var(--paper);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--muted);
+    margin: 0;
+}
+.meta .dot { width: 3px; height: 3px; border-radius: 50%; background: var(--muted); flex: none; }
+
+/* ---------- Empty state ---------- */
+.empty-state {
+    text-align: center;
+    padding: 80px 20px;
+    color: var(--muted);
+}
+.empty-emoji { font-size: 56px; margin: 0 0 14px; }
+.btn-ghost {
+    display: inline-block;
+    margin-top: 18px;
+    text-decoration: none;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--paper);
+    padding: 11px 22px;
+    border-radius: 999px;
+    border: 1px solid var(--line-strong);
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+.btn-ghost:hover { background: rgba(255, 99, 71, 0.14); border-color: var(--coral); }
+
+/* ---------- Watch page ---------- */
+.parent-container {
+    display: flex;
+    align-items: flex-start;
+    gap: clamp(16px, 2.5vw, 28px);
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 8px clamp(16px, 4vw, 40px) 64px;
 }
 
-/* Emoji styling with bounce */
-.error-emoji {
-    font-size: 150px;
-    animation: bounce 1.5s ease-in-out infinite, emojiHover 0.3s ease-in-out;
+.left-container {
+    width: 290px;
+    flex: none;
+    position: sticky;
+    top: 20px;
+    max-height: calc(100vh - 40px);
+    overflow-y: auto;
+}
+
+.watch-container { flex: 1; min-width: 0; }
+
+.watch-container .title h2 {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: clamp(22px, 3.5vw, 34px);
+    letter-spacing: -0.02em;
+    margin: 0 0 16px;
+}
+
+/* Player */
+.video-container {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: #000;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--line-strong);
+    box-shadow: var(--shadow);
+}
+.video-container iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+.no-video {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    color: var(--muted);
+    font-size: 15px;
+}
+.loading {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    color: var(--muted);
+    font-size: 14px;
+    z-index: 1;
+}
+.spinner {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    border: 3px solid rgba(244, 238, 240, 0.15);
+    border-top-color: var(--coral);
+    animation: spin 0.8s linear infinite;
+}
+
+/* Plot */
+.plot-container {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 22px 24px;
     margin-top: 20px;
-    transition: transform 0.3s ease-in-out;
+}
+.plot-container h2 {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 16px;
+    color: var(--coral);
+    margin: 0 0 10px;
+}
+.plot-container p {
+    margin: 0;
+    color: #e3dce0;
+    line-height: 1.7;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+.plot-container .error-message {
+    color: var(--coral-soft);
+    font-size: 14px;
 }
 
-/* Bounce animation for emoji */
-@keyframes bounce {
-    0%, 100% {
-        transform: translateY(0);
-    }
-    50% {
-        transform: translateY(-20px);
-    }
-}
-
-/* Hover effect for emoji */
-@keyframes emojiHover {
-    0%, 100% {
-        transform: scale(1);
-    }
-    50% {
-        transform: scale(1.2);
-    }
-}
-
-.error-emoji:hover {
-    animation: emojiHover 0.5s infinite ease-in-out;
-    transform: scale(1.2);
-}
-
-/* === Responsive Design === */
-@media (max-width: 768px) {
-    .parent-container {
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .left-container {
-        order: 2;
-        width: 100%;
-        max-width: 400px;
-    }
-
-    .watch-container {
-        flex: 1;
-        order: 1;
-        width: 100%;
-    }
-
-    .seasons-container {
-        width: 100%;
-        margin-top: 15px;
-    }
-
-    .error-container {
-        padding: 20px;
-    }
-    
-    .error-title {
-        font-size: 100px;
-    }
-    .error-message {
-        font-size: 16px;
-    }
-    .error-emoji {
-        font-size: 100px;
-    }
-
-    .error-container {
-        padding: 20px;
-    }
-    .error-title {
-        font-size: 100px;
-    }
-    .error-message {
-        font-size: 16px;
-    }
-    .error-emoji {
-        font-size: 100px;
-    }
-}
-
-@media (max-width: 480px) {
-    .title h1 {
-        font-size: 18px;
-    }
-
-    .title h2 {
-        font-size: 14px;
-    }
-
-    .home-button img {
-        width: 24px;
-    }
-
-    .plot-container {
-        font-size: 14px;
-        padding: 10px;
-    }
-
-    .error-title {
-        font-size: 70px;
-    }
-    .error-message {
-        font-size: 14px;
-        margin-bottom: 20px;
-    }
-    .error-emoji {
-        font-size: 70px;
-        margin-top: 10px;
-    }
-}
-
-.left-container::-webkit-scrollbar,
-.seasons-container::-webkit-scrollbar {
-    width: 8px;
-}
-
-.left-container::-webkit-scrollbar-track,
-.seasons-container::-webkit-scrollbar-track {
-    background: #1c1c1c;
-    border-radius: 4px;
-}
-
-.left-container::-webkit-scrollbar-thumb,
-.seasons-container::-webkit-scrollbar-thumb {
-    background-color: #ff6347;
-    border-radius: 4px;
-    border: 2px solid #1c1c1c;
-}
-
-.left-container::-webkit-scrollbar-thumb:hover,
-.seasons-container::-webkit-scrollbar-thumb:hover {
-    background-color: #e5533d;
-}
-
-/* Firefox scrollbar */
-.left-container,
+/* Seasons / episodes accordion */
 .seasons-container {
-    scrollbar-width: thin;
-    scrollbar-color: #ff6347 #1c1c1c;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 18px;
 }
+.seasons-container > h2 {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--muted);
+    margin: 2px 2px 14px;
+}
+
+.season-button {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 14px;
+    text-align: left;
+    color: var(--paper);
+    background: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    padding: 12px 14px;
+    margin: 8px 0;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+.season-button:hover { background: rgba(255, 99, 71, 0.12); border-color: rgba(255, 99, 71, 0.4); }
+.season-button .chev { color: var(--muted); transition: transform 0.3s ease; font-size: 14px; }
+.season-button:has(+ .episode-list.active) {
+    background: rgba(255, 99, 71, 0.14);
+    border-color: var(--coral);
+}
+.season-button:has(+ .episode-list.active) .chev { transform: rotate(180deg); color: var(--coral); }
+
+.episode-list {
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: max-height 0.35s ease, opacity 0.25s ease;
+}
+.episode-list.active { max-height: 2200px; opacity: 1; }
+.episode-list ul { list-style: none; margin: 4px 0 10px; padding: 0; }
+.episode-list li { border-radius: var(--radius-sm); }
+.episode-list li a {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    text-decoration: none;
+    color: #cbc3cf;
+    padding: 9px 12px;
+    border-radius: var(--radius-sm);
+    transition: background 0.18s ease, color 0.18s ease;
+}
+.episode-list li a:hover { background: rgba(244, 238, 240, 0.06); color: var(--paper); }
+.episode-list li .ep-num {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--coral);
+    flex: none;
+    min-width: 30px;
+}
+.episode-list li .ep-title {
+    font-size: 13px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.episode-list li.selected a {
+    background: rgba(255, 99, 71, 0.16);
+    color: var(--paper);
+}
+.episode-list li.selected .ep-title { font-weight: 600; }
+
+/* ---------- Error pages ---------- */
+.page-error { display: grid; place-items: center; }
+.error-container {
+    text-align: center;
+    padding: 40px 24px;
+    max-width: 520px;
+}
+.error-title {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: clamp(96px, 22vw, 168px);
+    line-height: 0.9;
+    letter-spacing: -0.04em;
+    margin: 0 0 8px;
+    background: linear-gradient(180deg, var(--coral) 0%, #b8412c 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+}
+.error-message { font-size: 16px; color: var(--muted); margin: 0 0 8px; }
+.error-emoji { font-size: 64px; margin: 18px 0 4px; animation: float 2.4s ease-in-out infinite; }
+
+/* ---------- Scrollbars ---------- */
+.left-container::-webkit-scrollbar { width: 8px; }
+.left-container::-webkit-scrollbar-track { background: transparent; }
+.left-container::-webkit-scrollbar-thumb {
+    background: rgba(255, 99, 71, 0.5);
+    border-radius: 999px;
+}
+.left-container::-webkit-scrollbar-thumb:hover { background: var(--coral); }
+.left-container { scrollbar-width: thin; scrollbar-color: rgba(255, 99, 71, 0.5) transparent; }
+
+/* ---------- Animations ---------- */
+@keyframes rise { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-12px); } }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 860px) {
+    .parent-container { flex-direction: column; }
+    .left-container {
+        width: 100%;
+        position: static;
+        max-height: none;
+        order: 2;
+    }
+    .watch-container { order: 1; width: 100%; }
+}
+
+@media (max-width: 520px) {
+    .results-grid { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
+    .search-field { flex-wrap: wrap; border-radius: 22px; }
+    .search-field button { width: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+    }
+}
+
+/* ---------- Poster fallback (missing / broken covers) ---------- */
+.poster-fallback {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 16px;
+    text-align: center;
+}
+.poster-fallback .pf-icon { font-size: 30px; opacity: 0.85; }
+.poster-fallback .pf-title {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 13px;
+    line-height: 1.3;
+    color: rgba(244, 238, 240, 0.85);
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.poster-wrap img { position: relative; z-index: 1; }
+.poster-scrim { z-index: 2; }
+.badge { z-index: 3; }
+.play-hint { z-index: 3; }
+
+.pf-c0 { background: linear-gradient(155deg, #221d33, #3a2740); }
+.pf-c1 { background: linear-gradient(155deg, #16242b, #23414a); }
+.pf-c2 { background: linear-gradient(155deg, #2a1f1d, #43302a); }
+.pf-c3 { background: linear-gradient(155deg, #1f1d33, #2a2350); }
+.pf-c4 { background: linear-gradient(155deg, #262213, #3a3420); }
+.pf-c5 { background: linear-gradient(155deg, #16221a, #243a2a); }
+
+/* ---------- Clearer rating badge ---------- */
+.badge-rating {
+    right: 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: rgba(10, 9, 14, 0.82);
+    color: #fff;
+    border: 1px solid rgba(255, 194, 122, 0.55);
+    font-size: 12px;
+    letter-spacing: 0;
+}
+.badge-rating .star { color: var(--amber); font-size: 12px; line-height: 1; }
+
+/* ---------- Recent searches dropdown ---------- */
+.search-form { position: relative; }
+.recent-panel {
+    position: absolute;
+    top: calc(100% + 10px);
+    left: 0;
+    right: 0;
+    z-index: 20;
+    display: none;
+    padding: 8px;
+    text-align: left;
+    background: rgba(20, 18, 28, 0.94);
+    border: 1px solid var(--line-strong);
+    border-radius: 18px;
+    backdrop-filter: blur(16px);
+    box-shadow: var(--shadow);
+}
+.recent-panel.open { display: block; animation: rise 0.22s ease both; }
+.recent-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px 6px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+.recent-clear {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--coral-soft);
+}
+.recent-clear:hover { color: var(--coral); }
+.recent-list { list-style: none; margin: 0; padding: 0; }
+.recent-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 12px;
+    transition: background 0.15s ease;
+}
+.recent-item:hover { background: rgba(255, 99, 71, 0.10); }
+.recent-go {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 11px 12px;
+    cursor: pointer;
+}
+.recent-ic {
+    width: 17px;
+    height: 17px;
+    flex: none;
+    fill: none;
+    stroke: var(--muted);
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+.recent-label {
+    font-family: var(--font-body);
+    font-size: 15px;
+    color: var(--paper);
+    text-transform: capitalize;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.recent-del {
+    flex: none;
+    margin-right: 6px;
+    width: 28px;
+    height: 28px;
+    border-radius: 999px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--muted);
+    font-size: 18px;
+    line-height: 1;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+.recent-del:hover { background: rgba(244, 238, 240, 0.08); color: var(--paper); }
+
+/* ---------- Recent searches dropdown ---------- */
+.search-wrap { position: relative; }
+.recents {
+    position: absolute;
+    top: calc(100% + 10px);
+    left: 0;
+    right: 0;
+    z-index: 5;
+    padding: 8px;
+    text-align: left;
+    background: rgba(21, 19, 29, 0.97);
+    border: 1px solid var(--line-strong);
+    border-radius: 18px;
+    backdrop-filter: blur(14px);
+    box-shadow: var(--shadow);
+    max-height: 340px;
+    overflow-y: auto;
+    animation: rise 0.18s ease both;
+}
+.recents-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 10px 8px;
+}
+.recents-head span {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+.recents-clear {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--coral-soft);
+    font-family: var(--font-body);
+    font-size: 12px;
+    padding: 4px 8px;
+    border-radius: 8px;
+}
+.recents-clear:hover { background: rgba(255, 99, 71, 0.12); }
+
+.recent-item { display: flex; align-items: center; gap: 4px; }
+.recent-go {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    color: var(--paper);
+    font-family: var(--font-body);
+    font-size: 15px;
+    padding: 10px 12px;
+    border-radius: 12px;
+}
+.recent-go svg {
+    width: 16px;
+    height: 16px;
+    flex: none;
+    fill: none;
+    stroke: var(--muted);
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+.recent-go span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.recent-go:hover { background: rgba(244, 238, 240, 0.06); }
+.recent-go:hover svg { stroke: var(--coral); }
+.recent-del {
+    flex: none;
+    width: 34px;
+    height: 34px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--muted);
+    font-size: 20px;
+    line-height: 1;
+    border-radius: 10px;
+}
+.recent-del:hover { background: rgba(255, 99, 71, 0.14); color: var(--coral); }
+
+/* ---------- Movie watch page (no episode sidebar) → centre the player ---------- */
+.parent-container.no-sidebar { justify-content: center; }
+.parent-container.no-sidebar .watch-container { max-width: 1024px; }

--- a/source/templates/500.html
+++ b/source/templates/500.html
@@ -3,7 +3,7 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
-    <title>404 &middot; Page not found</title>
+    <title>500 &middot; Something went wrong</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
@@ -15,9 +15,9 @@
         <img src="{{ url_for('static', filename='images/home-icon.png') }}" alt="" />
     </a>
     <div class="error-container">
-        <p class="error-title">404</p>
-        <p class="error-message">We couldn&rsquo;t find that page. It may have moved, or never existed.</p>
-        <p class="error-emoji">&#127902;</p>
+        <p class="error-title">500</p>
+        <p class="error-message">Something broke on our end. Give it a moment and try again.</p>
+        <p class="error-emoji">&#128296;</p>
         <a href="{{ url_for('index') }}" class="btn-ghost">Back to search</a>
     </div>
 </body>

--- a/source/templates/index.html
+++ b/source/templates/index.html
@@ -4,39 +4,137 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
     <title>Tmenyik</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <link rel="icon" sizes="16x16" href="{{ url_for('static', filename='images/app-logo.png') }}" type="image/png">
     <script>
+        const RECENTS_KEY = 'tmenyik:recent-searches';
+        const RECENTS_MAX = 8;
+
         function slugify(value) {
             value = value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
             value = value.replace(/[^a-zA-Z0-9]+/g, '-');
             return value.replace(/^-+|-+$/g, '');
         }
-        
+
+        function getRecents() {
+            try { return JSON.parse(localStorage.getItem(RECENTS_KEY)) || []; }
+            catch (e) { return []; }
+        }
+        function saveRecents(list) {
+            try { localStorage.setItem(RECENTS_KEY, JSON.stringify(list)); } catch (e) {}
+        }
+        function addRecent(query) {
+            const q = query.trim();
+            if (!q) return;
+            let list = getRecents().filter(item => item.toLowerCase() !== q.toLowerCase());
+            list.unshift(q);
+            saveRecents(list.slice(0, RECENTS_MAX));
+        }
+        function removeRecent(query) {
+            saveRecents(getRecents().filter(item => item !== query));
+            renderRecents(document.querySelector('input[name="movieName"]').value);
+        }
+        function clearRecents() {
+            saveRecents([]);
+            renderRecents();
+        }
+
+        function goToSearch(query) {
+            const slug = slugify(query);
+            if (!slug) return;
+            addRecent(query);
+            window.location.href = `/results/${slug}`;
+        }
+
         function searchMovie(event) {
             event.preventDefault();
-            const movieName = document.querySelector('input[name="movieName"]').value;
-            const searchRequest = slugify(movieName);
-            window.location.href = `/results/${searchRequest}`;
+            goToSearch(document.querySelector('input[name="movieName"]').value);
         }
+
+        function renderRecents(filter) {
+            const box = document.getElementById('recents');
+            let list = getRecents();
+            if (filter) {
+                const f = filter.trim().toLowerCase();
+                list = list.filter(q => q.toLowerCase().includes(f));
+            }
+            box.innerHTML = '';
+            if (!list.length) { box.hidden = true; return; }
+
+            const head = document.createElement('div');
+            head.className = 'recents-head';
+            const label = document.createElement('span');
+            label.textContent = 'Recent searches';
+            const clear = document.createElement('button');
+            clear.type = 'button';
+            clear.className = 'recents-clear';
+            clear.textContent = 'Clear';
+            clear.addEventListener('mousedown', e => { e.preventDefault(); clearRecents(); });
+            head.append(label, clear);
+            box.appendChild(head);
+
+            list.forEach(q => {
+                const row = document.createElement('div');
+                row.className = 'recent-item';
+
+                const go = document.createElement('button');
+                go.type = 'button';
+                go.className = 'recent-go';
+                go.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>';
+                const txt = document.createElement('span');
+                txt.textContent = q;
+                go.appendChild(txt);
+                go.addEventListener('mousedown', e => { e.preventDefault(); goToSearch(q); });
+
+                const del = document.createElement('button');
+                del.type = 'button';
+                del.className = 'recent-del';
+                del.setAttribute('aria-label', 'Remove ' + q);
+                del.textContent = '\u00d7';
+                del.addEventListener('mousedown', e => { e.preventDefault(); e.stopPropagation(); removeRecent(q); });
+
+                row.append(go, del);
+                box.appendChild(row);
+            });
+            box.hidden = false;
+        }
+
+        document.addEventListener('DOMContentLoaded', function () {
+            const input = document.querySelector('input[name="movieName"]');
+            const box = document.getElementById('recents');
+            input.addEventListener('focus', () => renderRecents(input.value));
+            input.addEventListener('input', () => renderRecents(input.value));
+            input.addEventListener('blur', () => { setTimeout(() => { box.hidden = true; }, 120); });
+            if (document.activeElement === input) renderRecents(input.value);
+        });
     </script>
 </head>
-<body>
-    <div class="container">
-        <a href="{{ url_for('index') }}" class="home-button">
-            <img src="{{ url_for('static', filename='images/home-icon.png') }}" alt="Home" />
+<body class="page-landing">
+    <div class="beam" aria-hidden="true"></div>
+    <main class="landing">
+        <a href="{{ url_for('index') }}" class="brand">
+            <img class="brand-mark" src="{{ url_for('static', filename='images/app-logo.png') }}" alt="">
+            <span class="brand-name">Tmenyik</span>
         </a>
-        <div class="title">
-            <h2>Tmenyik</h2>
-            <h1>Find Your Favorite Movie & Serie</h1>
-        </div>
+        <h1 class="hero-title">What are we<br>watching tonight?</h1>
+        <p class="hero-sub">Search thousands of movies and series, then press play.</p>
         {% if error %}
-            <p class="error">{{ error }}</p>
+            <p class="error" role="alert">{{ error }}</p>
         {% endif %}
         <form class="search-form" onsubmit="searchMovie(event)">
-            <input type="text" name="movieName" placeholder="Enter movie or series name..." required>
-            <button type="submit">Search</button>
+            <div class="search-wrap">
+                <div class="search-field">
+                    <svg class="search-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M21 21l-4.3-4.3M11 19a8 8 0 100-16 8 8 0 000 16z"/>
+                    </svg>
+                    <input type="text" name="movieName" placeholder="Try &ldquo;Interstellar&rdquo; or &ldquo;One Piece&rdquo;&hellip;" required autocomplete="off" autofocus>
+                    <button type="submit">Search</button>
+                </div>
+                <div class="recents" id="recents" hidden></div>
+            </div>
         </form>
-    </div>
+    </main>
 </body>
 </html>

--- a/source/templates/select.html
+++ b/source/templates/select.html
@@ -3,18 +3,29 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
-    <title>Search Results</title>
+    <title>Results &middot; {{ search_request|replace('-', ' ')|capitalize }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <link rel="icon" sizes="16x16" href="{{ url_for('static', filename='images/app-logo.png') }}" type="image/png">
 </head>
 <body>
-    <div class="container">
-        <a href="{{ url_for('index') }}" class="home-button">
-            <img src="{{ url_for('static', filename='images/home-icon.png') }}" alt="Home" />
+    <div class="beam beam-soft" aria-hidden="true"></div>
+    <header class="topbar">
+        <a href="{{ url_for('index') }}" class="brand brand-sm">
+            <img class="brand-mark" src="{{ url_for('static', filename='images/app-logo.png') }}" alt="">
+            <span class="brand-name">Tmenyik</span>
         </a>
-        <div class="title">
-            <h2>Results for {{ search_request|replace('-', ' ')|capitalize }}</h2>
+        <a href="{{ url_for('index') }}" class="home-button" aria-label="Home">
+            <img src="{{ url_for('static', filename='images/home-icon.png') }}" alt="" />
+        </a>
+    </header>
+    <main class="results-page">
+        <div class="results-head">
+            <p class="eyebrow">Search results</p>
+            <h1 class="results-title">{{ search_request|replace('-', ' ')|capitalize }}</h1>
         </div>
+        {% if results %}
         <div class="results-grid">
             {% for result in results %}
                 {% if result['Type'] == 'series' %}
@@ -22,21 +33,44 @@
                 {% else %}
                     {% set watch_url = url_for('watch', title=result['Title']|slugify, id=result['imdbID']) %}
                 {% endif %}
+                {% set has_poster = result['Poster'] and result['Poster'] != 'N/A' %}
                 <a href="{{ watch_url }}" class="result-card">
-                    <img src="{{ result['Poster'] if result['Poster'] != 'N/A' else url_for('static', filename='images/black-poster.jpg') }}" alt="Poster of {{ result['Title'] }}">
-                    <div class="result-info">
-                        <h2>{{ result['Title'] }}</h2>
-                        <p>{{ result['Type'] | replace('series', 'Serie') | capitalize | default('N/A') }} | {{ result['Year'] | default('N/A') }}</p>
-                        <p><strong>Rating:</strong> {{ result['imdbRating'] | default('N/A') }}</p>
-                        {% if result['Type'] == 'series' %}
-                            <p><strong>Seasons:</strong> {{ result['totalSeasons'] | default('N/A') }}</p>
-                        {% else %}
-                            <p><strong>Length:</strong> {{ result['Runtime'] | default('N/A') }}</p>
+                    <div class="poster-wrap">
+                        <div class="poster-fallback pf-c{{ loop.index0 % 6 }}" aria-hidden="true">
+                            <span class="pf-icon">&#127902;</span>
+                            <span class="pf-title">{{ result['Title'] }}</span>
+                        </div>
+                        {% if has_poster %}
+                            <img src="{{ result['Poster'] }}" alt="" loading="lazy" onerror="this.remove();">
                         {% endif %}
+                        <div class="poster-scrim"></div>
+                        <span class="badge badge-type">{{ result['Type'] | replace('series', 'Serie') | capitalize | default('N/A') }}</span>
+                        {% if result['imdbRating'] and result['imdbRating'] != 'N/A' %}
+                            <span class="badge badge-rating"><span class="star">&#9733;</span>{{ result['imdbRating'] }}</span>
+                        {% endif %}
+                        <span class="play-hint" aria-hidden="true">&#9654;</span>
+                    </div>
+                    <div class="result-info">
+                        <h2 title="{{ result['Title'] }}">{{ result['Title'] }}</h2>
+                        <p class="meta">
+                            <span>{{ result['Year'] | default('N/A') }}</span>
+                            {% if result['Type'] == 'series' %}
+                                <span class="dot"></span><span>{{ result['totalSeasons'] | default('N/A') }} seasons</span>
+                            {% else %}
+                                <span class="dot"></span><span>{{ result['Runtime'] | default('N/A') }}</span>
+                            {% endif %}
+                        </p>
                     </div>
                 </a>
             {% endfor %}
         </div>
-    </div>
+        {% else %}
+        <div class="empty-state">
+            <p class="empty-emoji">&#127916;</p>
+            <p>Nothing matched that search. Try another title.</p>
+            <a href="{{ url_for('index') }}" class="btn-ghost">New search</a>
+        </div>
+        {% endif %}
+    </main>
 </body>
 </html>

--- a/source/templates/watch.html
+++ b/source/templates/watch.html
@@ -3,60 +3,80 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
-    <title>Watching {{ title }}</title>
+    <title>{{ title }} &middot; Tmenyik</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <link rel="icon" sizes="16x16" href="{{ url_for('static', filename='images/app-logo.png') }}" type="image/png">
 </head>
 <body>
-    <a href="{{ url_for('index') }}" class="home-button">
-        <img src="{{ url_for('static', filename='images/home-icon.png') }}" alt="Home" />
-    </a>
-    <div class="parent-container">
+    <div class="beam beam-soft" aria-hidden="true"></div>
+    <header class="topbar">
+        <a href="{{ url_for('index') }}" class="brand brand-sm">
+            <img class="brand-mark" src="{{ url_for('static', filename='images/app-logo.png') }}" alt="">
+            <span class="brand-name">Tmenyik</span>
+        </a>
+        <a href="{{ url_for('index') }}" class="home-button" aria-label="Home">
+            <img src="{{ url_for('static', filename='images/home-icon.png') }}" alt="" />
+        </a>
+    </header>
+    {% set has_sidebar = (type == 'series' and seasons_object) %}
+    <div class="parent-container{% if not has_sidebar %} no-sidebar{% endif %}">
+        {% if has_sidebar %}
         <div class="left-container">
             <!-- All seasons & episodes -->
-            {% if type == 'series' and seasons_object %}
-                <div class="seasons-container">
-                    <h2>All Episodes</h2>
-                    {% for season, episodes in seasons_object.items() %}
-                        <div class="season-button" onclick="toggleEpisodes('{{ season }}')">
-                            {{ season }}
-                        </div>
-                        <div id="{{ season }}" class="episode-list">
-                            <ul>
-                                {% for episode in episodes %}
-                                    <li id="episode-{{ season.split(' ')[1] }}-{{ episode.episode }}" class="{{ 'selected' if episode.episode == current_episode else '' }}">
-                                        <a href="{{ url_for('watch', title=title.replace(' ', '-'), id=imdb_id, season=season.split(' ')[1], episode=episode.episode) }}">
-                                            Episode {{ episode.episode }}
-                                        </a>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        </div>
-                    {% endfor %}
-                </div>
-            {% endif %}
+            <div class="seasons-container">
+                <h2>Episodes</h2>
+                {% for season, episodes in seasons_object.items() %}
+                    <button type="button" class="season-button" onclick="toggleEpisodes('{{ season }}')">
+                        <span>{{ season }}</span>
+                        <span class="chev" aria-hidden="true">&#8964;</span>
+                    </button>
+                    <div id="{{ season }}" class="episode-list">
+                        <ul>
+                            {% for episode in episodes %}
+                                <li id="episode-{{ season.split(' ')[1] }}-{{ episode.episode }}" class="{{ 'selected' if episode.episode == current_episode else '' }}">
+                                    <a href="{{ url_for('watch', title=title.replace(' ', '-'), id=imdb_id, season=season.split(' ')[1], episode=episode.episode) }}">
+                                        <span class="ep-num">E{{ episode.episode }}</span>
+                                        <span class="ep-title">{{ episode.title }}</span>
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                {% endfor %}
+            </div>
         </div>
+        {% endif %}
         <!-- Movie/serie -->
         <div class="watch-container">
             <div class="title">
                 <h2>{{ title }}</h2>
             </div>
             <div class="video-container">
-                <!-- Loading message -->
-                <div class="loading" id="loading" style="display: none;">Loading video...</div>
+                <!-- Loading: visible by default, hidden once the iframe loads -->
+                <div class="loading" id="loading">
+                    <span class="spinner" aria-hidden="true"></span>
+                    <span>Loading video&hellip;</span>
+                </div>
                 {% if embed_url %}
-                    <iframe src="{{ embed_url }}" frameborder="0" allowfullscreen onload="document.getElementById('loading').style.display='none';"></iframe>
+                    <iframe src="{{ embed_url }}"
+                            title="{{ title }} player"
+                            referrerpolicy="no-referrer"
+                            allow="encrypted-media; fullscreen; picture-in-picture"
+                            allowfullscreen
+                            onload="document.getElementById('loading').style.display='none';"></iframe>
                 {% else %}
-                    <p>No video available.</p>
+                    <div class="no-video">No video available for this title.</div>
                 {% endif %}
             </div>
             <!-- Story line -->
             <div class="plot-container">
-                <h2>Story Line</h2>
+                <h2>Storyline</h2>
                 {% if error_message %}
                     <div class="error-message">{{ error_message }}</div>
                 {% else %}
-                    <p>{{ plot | safe }}</p>
+                    <p>{{ plot }}</p>
                 {% endif %}
             </div>
         </div>
@@ -66,40 +86,33 @@
             var selectedEpisodes = document.getElementById(seasonId);
 
             if (selectedEpisodes.classList.contains('active')) {
-                // If the selected list is already open, close it and clear saved season from localStorage
                 selectedEpisodes.classList.remove('active');
                 localStorage.removeItem('activeSeason');
             } else {
-                // Close other lists
-                var allEpisodes = document.querySelectorAll('.episode-list');
-                allEpisodes.forEach(function (el) {
+                document.querySelectorAll('.episode-list').forEach(function (el) {
                     el.classList.remove('active');
                 });
-
-                // Open the selected list and save the season ID to localStorage
                 selectedEpisodes.classList.add('active');
                 localStorage.setItem('activeSeason', seasonId);
             }
         }
 
-        // On page load, check if there is an active season in localStorage
         document.addEventListener('DOMContentLoaded', function () {
             var activeSeason = localStorage.getItem('activeSeason');
             if (activeSeason) {
-                var selectedEpisodes = document.getElementById(activeSeason);
-                if (selectedEpisodes) {
-                    selectedEpisodes.classList.add('active');
-                }
+                var el = document.getElementById(activeSeason);
+                if (el) el.classList.add('active');
             }
 
-            // Highlight the current episode based on URL
             var urlParams = new URLSearchParams(window.location.search);
             var currentSeason = urlParams.get('season');
             var currentEpisode = urlParams.get('episode');
             if (currentSeason && currentEpisode) {
-                var currentEpisodeElement = document.getElementById(`episode-${currentSeason}-${currentEpisode}`);
-                if (currentEpisodeElement) {
-                    currentEpisodeElement.classList.add('selected');
+                var cur = document.getElementById(`episode-${currentSeason}-${currentEpisode}`);
+                if (cur) {
+                    cur.classList.add('selected');
+                    var parentList = cur.closest('.episode-list');
+                    if (parentList) parentList.classList.add('active');
                 }
             }
         });


### PR DESCRIPTION
- fix cache decorator order; cache only successful results
- fail fast on DNS/connection errors, drop noisy retries
- filter OMDB results to movies and series (no games/episodes)
- poster fallback for missing covers, clearer rating badge
- center player for movies (no empty episode sidebar)
- recent searches via localStorage on the landing page
- cinema-at-night redesign (Bricolage/Inter/Space Mono, projector glow)
- add 404/500 pages, healthcheck, env config, slim Dockerfile